### PR TITLE
Remove use of `Math.random()`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ interface Computed<T> {
   get: () => T;
 }
 
+let conaKey = 0;
+
 export class Cona extends HTMLElement {
   private _op: Props;
   private props: Props;
@@ -156,14 +158,11 @@ export class Cona extends HTMLElement {
 
         if (s.endsWith("=")) {
           if (/(p:|on|ref).*$/.test(s)) {
-            const key = Math.random().toString(36);
-
-            Cona._c[key] =
+            valueString = conaKey++;
+            Cona._c[valueString] =
               typeof currentValue === "function"
                 ? currentValue.bind(this)
                 : currentValue;
-
-            valueString = key;
           } else valueString = JSON.stringify(currentValue);
         } else if (Array.isArray(currentValue)) {
           valueString = currentValue.join("");


### PR DESCRIPTION
Using `Math.random()` is considered insecure and automated tools will indiscriminately flag the code. In this case, you're looking for a unique key that could be assigned to an object, so an auto-incrementing number appears to be adequate and still provide a non-conflicting "id".