### PR TITLE
Force attributes to be properly encoded strings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -164,7 +164,13 @@ export class Cona extends HTMLElement {
                 : currentValue;
 
             valueString = key;
-          } else valueString = JSON.stringify(currentValue);
+          } else {
+              valueString = `${currentValue}`;
+              for (const letter of '&\'"<>\r\n'.split('')) {
+                  valueString = valueString.replaceAll(letter, `&#${letter.charCodeAt(0)};`);
+              }
+              valueString = `"${valueString}"`;
+          }
         } else if (Array.isArray(currentValue)) {
           valueString = currentValue.join("");
         }


### PR DESCRIPTION
It is difficult to pass strings to elements. Imagine this template fragment

```js
render(h) {
    const title='X " onclick='alert(document.location)' Y';
    return h`<div title=${title}></div>`;
}
```

The result would look like this

```html
<div title="X \" onclick='alert(document.location)' Y"></div>
```

I hope this illustrates the issue with not properly quoting the string.

The only problem is if a template is using a number. In HTML all attributes are strings and this change would alter the generated HTML.

```
render(h) {
    return h`<input size=${10}/>`;
}
```

Before my change this would result in

```html
<input size=10/>
```

After this change, you now have explicit quotes.

```html
<input size="10"/>
```
    